### PR TITLE
Fix dllexport on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ if (COMPILER_SUPPORTS_CXX11)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
 
+add_definitions(-D_MSDFGEN_BUILD_DLL=1)
+
+
 # Make release mode default (turn on optimizations)
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)

--- a/msdfgen-c.h
+++ b/msdfgen-c.h
@@ -2,6 +2,18 @@
 
 #include <stdint.h>
 
+#if defined(_WIN32) && defined(_MSDFGEN_BUILD_DLL)
+/* We are building MSDFgen as a Win32 DLL */
+#define MSDFGEN_API __declspec(dllexport)
+#elif defined(_WIN32)
+/* We are calling MSDFgen as a Win32 DLL */
+#define MSDFGEN_API  __declspec(dllimport)
+#elif defined(__GNUC__)
+/* We are building MSDFgen as a shared / dynamic library */
+#define MSDFGEN_API  __attribute__((visibility("default")))
+#endif
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -13,15 +25,15 @@ typedef struct msEdge msEdge;
 typedef struct msContour msContour;
 typedef struct msShape msShape;
 
-msShape* msShapeCreate(void);
-void msShapeDestroy(msShape* shape);
-msContour* msShapeAddContour(msShape* shape);
-void msShapeNormalize(msShape* cShape);
-void msEdgeColoringSimple(msShape* cShape, double angleThreshold, unsigned long long seed);
-void msContourAddLinearEdge(msContour* cContour, float x1, float y1, float x2, float y2);
-void msContourAddQuadraticEdge(msContour* cContour, float x1, float y1, float x2, float y2, float x3, float y3);
-void msContourAddCubicEdge(msContour* cContour, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4);
-void msGenerateMSDF(uint8_t* data, int w, int h, msShape* shape, float range, float sx, float sy, float dx, float dy);
+MSDFGEN_API msShape* msShapeCreate(void);
+MSDFGEN_API void msShapeDestroy(msShape* shape);
+MSDFGEN_API msContour* msShapeAddContour(msShape* shape);
+MSDFGEN_API void msShapeNormalize(msShape* cShape);
+MSDFGEN_API void msEdgeColoringSimple(msShape* cShape, double angleThreshold, unsigned long long seed);
+MSDFGEN_API void msContourAddLinearEdge(msContour* cContour, float x1, float y1, float x2, float y2);
+MSDFGEN_API void msContourAddQuadraticEdge(msContour* cContour, float x1, float y1, float x2, float y2, float x3, float y3);
+MSDFGEN_API void msContourAddCubicEdge(msContour* cContour, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4);
+MSDFGEN_API void msGenerateMSDF(uint8_t* data, int w, int h, msShape* shape, float range, float sx, float sy, float dx, float dy);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When built as a dynamic library, public symbols need to be marked with dllexport so that a lib file is generated.